### PR TITLE
Java modularisation

### DIFF
--- a/matchbook-sdk-core/pom.xml
+++ b/matchbook-sdk-core/pom.xml
@@ -5,11 +5,15 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
+        <groupId>com.matchbook.sdk</groupId>
         <artifactId>matchbook-sdk</artifactId>
-        <groupId>com.matchbook</groupId>
         <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>matchbook-sdk-core</artifactId>
+
+    <properties>
+        <project.automatic.module.name>com.matchbook.sdk.core</project.automatic.module.name>
+    </properties>
 
 </project>

--- a/matchbook-sdk-core/src/main/java/module-info.java
+++ b/matchbook-sdk-core/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module com.matchbook.sdk.core {
+
+    exports com.matchbook.sdk.core;
+    exports com.matchbook.sdk.core.exceptions;
+
+}

--- a/matchbook-sdk-rest/pom.xml
+++ b/matchbook-sdk-rest/pom.xml
@@ -5,17 +5,21 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
+        <groupId>com.matchbook.sdk</groupId>
         <artifactId>matchbook-sdk</artifactId>
-        <groupId>com.matchbook</groupId>
         <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>matchbook-sdk-rest</artifactId>
 
+    <properties>
+        <project.automatic.module.name>com.matchbook.sdk.rest</project.automatic.module.name>
+    </properties>
+
     <dependencies>
         <!--Matchbook SDK-->
         <dependency>
-            <groupId>com.matchbook</groupId>
+            <groupId>com.matchbook.sdk</groupId>
             <artifactId>matchbook-sdk-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/matchbook-sdk-rest/src/main/java/module-info.java
+++ b/matchbook-sdk-rest/src/main/java/module-info.java
@@ -1,0 +1,15 @@
+module com.matchbook.sdk.rest {
+
+    exports com.matchbook.sdk.rest;
+    exports com.matchbook.sdk.rest.dtos;
+
+    requires com.matchbook.sdk.core;
+    requires com.fasterxml.jackson.core;
+    requires com.fasterxml.jackson.databind;
+    requires com.fasterxml.jackson.datatype.jdk8;
+    requires com.fasterxml.jackson.datatype.jsr310;
+    requires com.fasterxml.jackson.module.paramnames;
+    requires org.slf4j;
+    requires okhttp3;
+
+}

--- a/matchbook-sdk-stream/pom.xml
+++ b/matchbook-sdk-stream/pom.xml
@@ -5,17 +5,21 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
+        <groupId>com.matchbook.sdk</groupId>
         <artifactId>matchbook-sdk</artifactId>
-        <groupId>com.matchbook</groupId>
         <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>matchbook-sdk-stream</artifactId>
 
+    <properties>
+        <project.automatic.module.name>com.matchbook.sdk.stream</project.automatic.module.name>
+    </properties>
+
     <dependencies>
         <!--Matchbook SDK-->
         <dependency>
-            <groupId>com.matchbook</groupId>
+            <groupId>com.matchbook.sdk</groupId>
             <artifactId>matchbook-sdk-rest</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/matchbook-sdk-stream/src/main/java/module-info.java
+++ b/matchbook-sdk-stream/src/main/java/module-info.java
@@ -1,0 +1,10 @@
+module com.matchbook.sdk.stream {
+
+    exports com.matchbook.sdk.stream;
+
+    requires com.matchbook.sdk.core;
+    requires com.matchbook.sdk.rest;
+    requires org.slf4j;
+    requires disruptor;
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     </licenses>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.9</maven.compiler.source>
+        <maven.compiler.target>1.9</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.automatic.module.name>com.matchbook.sdk</project.automatic.module.name>
@@ -44,13 +44,13 @@
         <assertj.version>3.11.1</assertj.version>
         <wiremock.version>2.21.0</wiremock.version>
         <mockito.version>1.10.19</mockito.version>
-        <slf4j.version>1.7.26</slf4j.version>
+        <slf4j.version>1.7.28</slf4j.version>
         <logback.version>1.2.3</logback.version>
         <junit.version>4.12</junit.version>
 
         <!-- Maven plugins -->
         <maven.jar.plugin.version>3.1.2</maven.jar.plugin.version>
-        <maven.compiler.plugin.version>3.6.1</maven.compiler.plugin.version>
+        <maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
         <maven.surefire.plugin.version>2.22.1</maven.surefire.plugin.version>
         <maven.jacoco.plugin.version>0.8.2</maven.jacoco.plugin.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.matchbook</groupId>
+    <groupId>com.matchbook.sdk</groupId>
     <artifactId>matchbook-sdk</artifactId>
     <packaging>pom</packaging>
     <version>0.1.0-SNAPSHOT</version>
@@ -35,6 +35,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <project.automatic.module.name>com.matchbook.sdk</project.automatic.module.name>
 
         <!-- Application dependencies -->
         <okhttp.version>4.0.1</okhttp.version>
@@ -48,6 +49,7 @@
         <junit.version>4.12</junit.version>
 
         <!-- Maven plugins -->
+        <maven.jar.plugin.version>3.1.2</maven.jar.plugin.version>
         <maven.compiler.plugin.version>3.6.1</maven.compiler.plugin.version>
         <maven.surefire.plugin.version>2.22.1</maven.surefire.plugin.version>
         <maven.jacoco.plugin.version>0.8.2</maven.jacoco.plugin.version>
@@ -55,6 +57,18 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven.jar.plugin.version}</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${project.automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
These changes make the library compliant with the Java 9 modular system adding module-info.java to the subprojects.
One aspect we may want to discuss is the java version we want the library to be compatible with.
I updated the compiler level from 1.8 to 1.9, to be able to compile the new module-info file, that though might reduce the audience of who is going to be able to use the library as maybe a lot of applications are still on Java 8 or older versions.
There are workarounds, like the one described below, but it adds complexity to the compilation process:
https://maven.apache.org/plugins/maven-compiler-plugin/examples/module-info.html
I can look into it if you think we should guarantee Java 8 compatibility.