### PR TITLE
build project for source and target version 1.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - run:
           name: Build Matchbook SDK on Java 11
           command: |
-            mvn clean verify -Dmaven.compiler.source=11 -Dmaven.compiler.target=11
+            mvn clean verify
 
 workflows:
   version: 2


### PR DESCRIPTION
Well, I know we have an some conversation ongoing in the different branch about building a source code with a java 11 target version. 
I think that we should try to keep the build process as simple as possible, so for now, let's just check if the project can compile on a java 11. So, we need to remove the building project in different java versions 
